### PR TITLE
Add the ability to log a maximum number of entries

### DIFF
--- a/include/sql_db.h
+++ b/include/sql_db.h
@@ -19,15 +19,20 @@ typedef struct {
 class Elevator_db {
 public:
 
-    Elevator_db();
+    Elevator_db(uint16_t n_floor_history, uint16_t n_log_history);
     ~Elevator_db();
 
     int db_get_floor_request();
     void db_set_floor_request(int floor);
     void db_set_can_log(msg_log to_log);
-private:
 
+private:
     Driver *driver;  // Create a pointer to a MySQL driver object
     Connection *con; // Create a pointer to a database connection object
     ResultSet *res;  // Create a pointer to a ResultSet object to hold results
+    uint16_t n_floors;
+    uint16_t n_logs;
+
+    int manage_n_logs();
+    int manage_n_floors();
 };

--- a/src/sql_db.cpp
+++ b/src/sql_db.cpp
@@ -9,10 +9,11 @@
 #include <mysql_connection.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 using namespace std;
 
-Elevator_db::Elevator_db() {
+Elevator_db::Elevator_db(uint16_t n_floor_history, uint16_t n_log_history): n_floors(n_floor_history), n_logs(n_log_history) {
     driver = get_driver_instance();
     con = driver->connect("tcp://127.0.0.1:3306", "ese", "ese");
     con->setSchema("elevator");
@@ -23,9 +24,80 @@ Elevator_db::~Elevator_db() {
     delete con;
 }
 
+int Elevator_db::manage_n_logs() {
+    int counter = 0;
+
+    uint16_t n_logs_to_remove = 0;
+    uint32_t  *epoch_time_arr;
+    sql::PreparedStatement *pstmt; // Create a pointer to a prepared statement
+    Statement *stmt; // Crealte a pointer to a Statement object to hold statements
+
+    stmt = con->createStatement();
+    res = stmt->executeQuery(
+        "SELECT epoch_time FROM logging_table "); // message
+                                                                      // query
+    while (res->next()) {
+        counter++;
+       /* new_epoch = res->getInt("epoch_time");
+        if (first_check == true) {
+            oldest_epoch = new_epoch;
+            first_check = false;
+        } else if (oldest_epoch > new_epoch) {
+            oldest_epoch = new_epoch;
+        }
+        */
+    }
+    if (counter < n_logs) {
+        return 0;
+    }
+
+    n_logs_to_remove = counter - n_floors;
+    epoch_time_arr = (uint32_t*)calloc(n_logs_to_remove, sizeof(uint32_t));
+
+    stmt = con->createStatement();
+    res = stmt->executeQuery(
+        "SELECT epoch_time FROM logging_table"); // message
+    for (int i = 0; i < n_logs_to_remove; i++) {
+        res->next();
+        epoch_time_arr[i] = res->getInt("epoch_time");
+    }
+
+    for (int i =0; i < n_logs_to_remove; i++) {
+        pstmt = con->prepareStatement(
+            "DELETE FROM logging_table WHERE epoch_time = ?");
+        pstmt->setInt(1, epoch_time_arr[i]);
+        pstmt->executeUpdate();
+    }
+
+    delete stmt; //may need to move to get db
+    delete pstmt;
+    free(epoch_time_arr);
+    return n_logs_to_remove;
+}
+
+int Elevator_db::manage_n_floors() {
+    uint16_t counter = 0;
+    Statement *stmt; // Crealte a pointer to a Statement object to hold statements
+
+    stmt = con->createStatement();
+    res = stmt->executeQuery(
+        "SELECT requestedFloor FROM elevatorNetwork WHERE nodeID = 1"); // message
+                                                                      // query
+    while (res->next()) {
+        counter++;
+    }
+    if (counter < n_floors) {
+        return 0;
+    }
+    delete stmt; //may need to move to get db
+    return counter;
+
+}
+
 int Elevator_db::db_get_floor_request() {
     int floorNum;
     Statement *stmt; // Crealte a pointer to a Statement object to hold statements
+
     stmt = con->createStatement();
     res = stmt->executeQuery(
         "SELECT requestedFloor FROM elevatorNetwork WHERE nodeID = 1"); // message
@@ -53,7 +125,7 @@ void Elevator_db::db_set_floor_request(int floor) {
 void Elevator_db::db_set_can_log(msg_log to_log) {
     sql::PreparedStatement *pstmt; // Create a pointer to a prepared statement
     printf("%s, logging the following: epoch time %d, node %d, %d\n", __func__, to_log.epoch_time, to_log.node_id, to_log.msg);
-
+    manage_n_logs();
     pstmt = con->prepareStatement(
         "INSERT INTO logging_table VALUES(?,?,?)");
     pstmt->setInt(1, to_log.epoch_time);

--- a/src/supervisorProgram.cpp
+++ b/src/supervisorProgram.cpp
@@ -13,11 +13,12 @@
 #include <time.h>
 
 #include "pcanFunctions.h"
-
+#define NUMBER_OF_FLOORS 50
+#define NUMBER_OF_LOGS 50
 static HANDLE h_TX;
 static HANDLE h_RX;
 static int current_floor = 0;
-static Elevator_db db;
+static Elevator_db db(NUMBER_OF_FLOORS,NUMBER_OF_LOGS);
 
 // TODO: add error check to can init and can status
 static bool init_can_bus() {


### PR DESCRIPTION
This change is to add the ability to hold a finite number of entries in
our log table for logging can bus messages. currently the max is set at
50 messages. eventually we would like to switch the table
elevatornetwork to use epoch time so we can keep a maximum number of
entries the same way